### PR TITLE
public proxy: run nginx with screen to avoid log to docker

### DIFF
--- a/proxy_public/run.sh
+++ b/proxy_public/run.sh
@@ -1,5 +1,5 @@
 pacman -Syu --noconfirm
-pacman -S --noconfirm base-devel wget dnsutils nginx cronie
+pacman -S --noconfirm base-devel wget dnsutils nginx cronie screen
 
 ########################################################################################################################
 # SSL for notional.ventures (fullchain.pem and privkey.pem files)
@@ -49,9 +49,9 @@ echo "UPSTREAM_CONFIG_FILE_TMP=$UPSTREAM_CONFIG_FILE_TMP"
 sleep 1
 cat "$UPSTREAM_CONFIG_FILE_TMP" > "$UPSTREAM_CONFIG_FILE"
 sleep 1
-#/usr/sbin/nginx -g "daemon off;"
-/usr/sbin/nginx
 
+# run nginx with screen to avoid log to docker
+screen -S nginx -dm /usr/sbin/nginx -g "daemon off;"
 
 ########################################################################################################################
 # cron


### PR DESCRIPTION
The docker log full of rate-limiting err:
```
2022/09/10 11:51:36 [error] 669#669: *1045 limiting requests, excess: 300.381 by zone "ip", client: x.x.x.x
...
```

Run nginx with screen to avoid log on docker