### PR TITLE
add a service to backup notionalapi db daily

### DIFF
--- a/notionalapi/db_backup/README.md
+++ b/notionalapi/db_backup/README.md
@@ -1,0 +1,5 @@
+# napi_dbbackup
+
+A service to backup notionalapi db twice a day. Data is stored on `/mnt/data/napi_dbbackup`.
+
+Requires to created `/mnt/data/napi_dbbackup` on host.

--- a/notionalapi/db_backup/README.md
+++ b/notionalapi/db_backup/README.md
@@ -1,5 +1,5 @@
-# napi_dbbackup
+# NAPI Database Backup Service
 
-A service to backup notionalapi db twice a day. Data is stored on `/mnt/data/napi_dbbackup`.
+A service to back up the NotionalAPI database twice a day. Data is stored in `/mnt/data/napi_dbbackup`.
 
-Requires to created `/mnt/data/napi_dbbackup` on host.
+Requires creating the `/mnt/data/napi_dbbackup` directory on the host.

--- a/notionalapi/db_backup/backup.sh
+++ b/notionalapi/db_backup/backup.sh
@@ -1,0 +1,4 @@
+cd $HOME
+
+SQL_FILENAME="napidb_$(date +%Y%m%d_%T |sed 's/://g').sql"
+curl -s -XGET http://tasks.napidb_1:4001/db/backup?fmt=sql -o "/data/${SQL_FILENAME}.sql"

--- a/notionalapi/db_backup/backup.sh
+++ b/notionalapi/db_backup/backup.sh
@@ -1,4 +1,4 @@
 cd $HOME
 
 SQL_FILENAME="napidb_$(date +%Y%m%d_%T |sed 's/://g').sql"
-curl -s -XGET http://tasks.napidb_1:4001/db/backup?fmt=sql -o "/data/${SQL_FILENAME}.sql"
+curl -s -XGET http://tasks.napidb_1:4001/db/backup?fmt=sql -o "/data/${SQL_FILENAME}"

--- a/notionalapi/db_backup/docker_service_create.sh
+++ b/notionalapi/db_backup/docker_service_create.sh
@@ -1,0 +1,18 @@
+
+SERVICE_NAME="napi_dbbackup"
+
+# delete existing service
+docker service rm $SERVICE_NAME
+
+# create new service
+docker service create \
+  --name $SERVICE_NAME \
+  --replicas 1 \
+  --network notionalapi \
+  --constraint 'node.hostname==cosmosia21' \
+  --endpoint-mode dnsrr \
+  --restart-condition none \
+  --mount type=bind,source=/mnt/data/napi_dbbackup,destination=/data \
+  archlinux:latest \
+  /bin/bash -c \
+  "curl -s https://raw.githubusercontent.com/notional-labs/cosmosia/583-add-a-service-to-backup-notionalapi-db-daily/notionalapi/db_backup/run.sh > ~/run.sh && /bin/bash ~/run.sh"

--- a/notionalapi/db_backup/docker_service_create.sh
+++ b/notionalapi/db_backup/docker_service_create.sh
@@ -15,4 +15,4 @@ docker service create \
   --mount type=bind,source=/mnt/data/napi_dbbackup,destination=/data \
   archlinux:latest \
   /bin/bash -c \
-  "curl -s https://raw.githubusercontent.com/notional-labs/cosmosia/583-add-a-service-to-backup-notionalapi-db-daily/notionalapi/db_backup/run.sh > ~/run.sh && /bin/bash ~/run.sh"
+  "curl -s https://raw.githubusercontent.com/notional-labs/cosmosia/main/notionalapi/db_backup/run.sh > ~/run.sh && /bin/bash ~/run.sh"

--- a/notionalapi/db_backup/run.sh
+++ b/notionalapi/db_backup/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 pacman -Syu --noconfirm
 pacman -S --noconfirm cronie
 

--- a/notionalapi/db_backup/run.sh
+++ b/notionalapi/db_backup/run.sh
@@ -20,5 +20,5 @@ curl -Ls "https://raw.githubusercontent.com/notional-labs/cosmosia/main/notional
 echo "0 */12 * * * root /bin/bash $HOME/backup.sh" > /etc/cron.d/cron_backup
 
 
-# loop forever for debugging only
+# loop forever
 while true; do sleep 5; done

--- a/notionalapi/db_backup/run.sh
+++ b/notionalapi/db_backup/run.sh
@@ -1,0 +1,23 @@
+pacman -Syu --noconfirm
+pacman -S --noconfirm cronie
+
+cd $HOME
+
+#############################################################################
+# install (no need to install)
+#cd $HOME
+#curl -L https://github.com/rqlite/rqlite/releases/download/v7.21.4/rqlite-v7.21.4-linux-amd64.tar.gz -o rqlite-v7.21.4-linux-amd64.tar.gz
+#tar xvfz rqlite-v7.21.4-linux-amd64.tar.gz
+#cd rqlite-v7.21.4-linux-amd64
+#./rqlited ~/node.1
+
+
+#########
+# setup cronjob
+curl -Ls "https://raw.githubusercontent.com/notional-labs/cosmosia/583-add-a-service-to-backup-notionalapi-db-daily/notionalapi/db_backup/backup.sh" > $HOME/backup.sh
+
+echo "0 */12 * * * root /bin/bash $HOME/backup.sh" > /etc/cron.d/cron_backup
+
+
+# loop forever for debugging only
+while true; do sleep 5; done

--- a/notionalapi/db_backup/run.sh
+++ b/notionalapi/db_backup/run.sh
@@ -14,7 +14,7 @@ cd $HOME
 
 #########
 # setup cronjob
-curl -Ls "https://raw.githubusercontent.com/notional-labs/cosmosia/583-add-a-service-to-backup-notionalapi-db-daily/notionalapi/db_backup/backup.sh" > $HOME/backup.sh
+curl -Ls "https://raw.githubusercontent.com/notional-labs/cosmosia/main/notionalapi/db_backup/backup.sh" > $HOME/backup.sh
 
 echo "0 */12 * * * root /bin/bash $HOME/backup.sh" > /etc/cron.d/cron_backup
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a new backup service for the NotionalAPI database, ensuring data is backed up twice daily.
    - Added functionality to manage a Docker service specifically for database backups, including service creation and deletion.
    - Implemented a script to facilitate database backup by fetching a SQL dump and saving it with a timestamped filename.
    - Included a script to install necessary packages, set up a cron job for database backup, and provide a debugging loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->