### PR TITLE
upgrade: upgrade script - fetch new config before build at step 4

### DIFF
--- a/rpc/scripts/upgrading.sh
+++ b/rpc/scripts/upgrading.sh
@@ -1,6 +1,92 @@
 # usage: ./upgrading.sh <new_version>
 # eg., ./upgrading.sh v6.0.1
 
+# get snapshot config functions
+get_docker_snapshot_config () {
+  str_snapshot_cfg="$(curl -s "http://tasks.web_config/config/cosmosia.snapshot.${chain_name}" |sed 's/ = /=/g')"
+  echo $str_snapshot_cfg
+}
+
+########################################################################################################################
+# fetch new chain configuration
+upgrade_config () {
+
+# activate old env vars
+echo "read chain info:"
+
+# to get the url to the config file
+eval "$(curl -s "$CHAIN_REGISTRY_INI_URL" |awk -v TARGET=$chain_name -F ' = ' '
+  {
+    if ($0 ~ /^\[.*\]$/) {
+      gsub(/^\[|\]$/, "", $0)
+      SECTION=$0
+    } else if (($2 != "") && (SECTION==TARGET)) {
+      print $1 "=" $2
+    }
+  }
+  ')"
+
+echo "config=$config"
+
+# load config
+eval "$(curl -s "$config" |sed 's/ = /=/g')"
+
+# fix injective close-source
+if [[ $git_repo == "https://github.com/InjectiveLabs/injective-core" ]]; then
+  gh_access_token="$(curl -s "http://tasks.web_config/config/gh_access_token")"
+  git_repo="https://${gh_access_token}@github.com/InjectiveLabs/injective-core"
+fi
+
+# figure out IP of the snapshot_storage_node
+snapshot_storage_node_ip=$(curl -s "http://tasks.web_config/node_ip/${snapshot_storage_node}")
+
+# fetch snapshot configuration
+str_snapshot_cfg=$(get_docker_snapshot_config)
+echo "str_snapshot_cfg=${str_snapshot_cfg}"
+eval "${str_snapshot_cfg}"
+
+# remove old env vars
+rm $HOME/env.sh
+
+# write env vars to bash file, so that cronjobs or other scripts could know
+cat <<EOT >> $HOME/env.sh
+chain_name="$chain_name"
+git_repo="$git_repo"
+version="$version"
+daemon_name="$daemon_name"
+node_home="$node_home"
+minimum_gas_prices="$minimum_gas_prices"
+start_flags="$start_flags"
+snapshot_node="$snapshot_node"
+snapshot_storage_node="$snapshot_storage_node"
+snapshot_storage_node_ip="$snapshot_storage_node_ip"
+snapshot_prune="$snapshot_prune"
+db_backend="$db_backend"
+go_version="$go_version"
+build_script="$build_script"
+EOT
+
+if [ $( echo "${chain_name}" | grep -cE "agoric" ) -ne 0 ]; then
+  cat <<EOT >> ./env.sh
+# fix agoric
+export NVM_DIR="\$HOME/.nvm"
+[ -s "\$NVM_DIR/nvm.sh" ] && \. "\$NVM_DIR/nvm.sh" # This loads nvm
+[ -s "\$NVM_DIR/bash_completion" ] && \. "\$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+EOT
+fi
+
+# remove old start chain script
+rm $HOME/start_chain.sh
+
+# start_chain.sh script
+cat <<EOT >> $HOME/start_chain.sh
+source $HOME/env.sh
+# fix supervisorctl creates a dbus-daemon process everytime starting chain
+killall dbus-daemon
+$HOME/go/bin/$daemon_name start $start_flags 1>&2
+EOT
+}
+
 ########################################################################################################################
 # make sure single instance running
 PIDFILE="$HOME/upgrading.sh.lock"
@@ -155,6 +241,8 @@ sleep 5;
 echo "step 4"
 supervisorctl stop chain
 sleep 5;
+upgrade_config
+sleep 5;
 buid_chain "$version_new" "false"
 sleep 5;
 supervisorctl start chain
@@ -172,3 +260,4 @@ done
 
 ##############
 echo "synched"
+


### PR DESCRIPTION
This new script will automatically fetch latest start flags, minimum prices, go version,...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the upgrade script to support snapshot configurations and chain upgrades.
	- Improved handling of environment variables for better integration with other scripts and cronjobs.

- **Bug Fixes**
	- Fixed an issue in the `start_chain.sh` script related to `supervisorctl` and `dbus-daemon` processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->